### PR TITLE
[DEV-16433] extend laser driver to publish breaching of safety zones to ros

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package urg_node
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Fix parsing of optical_window_contaminated
+* README syntax updates (`#112 <https://github.com/ubica-robotics/urg_node/issues/112>`_)
+  Updates to ROS 2 syntax and minor rewording. I also moved RViz to the
+  visualization section.
+
 1.1.1 (2023-03-18)
 ------------------
 * add branch information
@@ -10,6 +17,7 @@ Changelog for package urg_node
   This is just a quick PR to increase the thread sleep in the diagnostics thread. Currently the diagnostics status is updated at ~96hz. Which is way too fast and really messes with the Frequency Status Monitor which jumps between too low and too high
 * Added URDF for UST10. (`#103 <https://github.com/ros-drivers/urg_node/issues/103>`_)
 * Contributors: Michael Ferguson, Richard, Tony Baltovski
+
 
 1.1.0 (2021-03-31)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package urg_node
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+101.2.1 (2025-03-31)
+--------------------
 * Fix parsing of optical_window_contaminated
 * README syntax updates (`#112 <https://github.com/ubica-robotics/urg_node/issues/112>`_)
   Updates to ROS 2 syntax and minor rewording. I also moved RViz to the

--- a/include/urg_node/urg_c_wrapper.hpp
+++ b/include/urg_node/urg_c_wrapper.hpp
@@ -64,6 +64,8 @@ public:
     error_code = 0;
     lockout_status = false;
     optical_window_contaminated = false;
+    ossd_1 = false;
+    ossd_2 = false;
   }
 
   uint16_t status;
@@ -73,6 +75,8 @@ public:
   uint16_t error_code;
   bool lockout_status;
   bool optical_window_contaminated;
+  bool ossd_1;
+  bool ossd_2;
 };
 
 class UrgDetectionReport

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>urg_node</name>
-  <version>1.1.1</version>
+  <version>101.2.1</version>
   <description>urg_node</description>
 
   <maintainer email="mfergs7@gmail.com">Michael Ferguson</maintainer>

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -397,12 +397,12 @@ bool URGCWrapper::getAR00Status(URGStatus & status)
   uint16_t unused0;
 
   s = response.substr(17, 1);
-  unused0 = std::stoul(s, nullptr, 16);
-  RCLCPP_DEBUG(logger_, "OSSD 1: 0x%s = %d", s.c_str(), unused0);
+  status.ossd_1 = std::stoul(s, nullptr, 16);
+  RCLCPP_DEBUG(logger_, "OSSD 1: 0x%s = %d", s.c_str(), status.ossd_1);
 
   s = response.substr(18, 1);
-  unused0 = std::stoul(s, nullptr, 16);
-  RCLCPP_DEBUG(logger_, "OSSD 2: 0x%s = %d", s.c_str(), unused0);
+  status.ossd_2 = std::stoul(s, nullptr, 16);
+  RCLCPP_DEBUG(logger_, "OSSD 2: 0x%s = %d", s.c_str(), status.ossd_2);
 
   s = response.substr(19, 1);
   unused0 = std::stoul(s, nullptr, 16);

--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -167,6 +167,8 @@ bool UrgNode::updateStatus()
         msg.error_code = status.error_code;
         msg.lockout_status = status.lockout_status;
         msg.optical_window_contaminated = status.optical_window_contaminated;
+        msg.ossd_1 = status.ossd_1;
+        msg.ossd_2 = status.ossd_2;
 
         lockout_status_ = status.lockout_status;
         error_code_ = status.error_code;


### PR DESCRIPTION
Reads the ossd_1 and ossd_2 value from the response of the sent AR00 command and publishes it to ROS.