### PR TITLE
[DEV-16433] extend laser driver to publish breaching of safety zones to ros corrected branch

### DIFF
--- a/include/urg_node/urg_c_wrapper.hpp
+++ b/include/urg_node/urg_c_wrapper.hpp
@@ -64,6 +64,8 @@ public:
     error_code = 0;
     lockout_status = false;
     optical_window_contaminated = false;
+    ossd_1 = false;
+    ossd_2 = false;
   }
 
   uint16_t status;
@@ -73,6 +75,8 @@ public:
   uint16_t error_code;
   bool lockout_status;
   bool optical_window_contaminated;
+  bool ossd_1;
+  bool ossd_2;
 };
 
 class UrgDetectionReport

--- a/src/urg_c_wrapper.cpp
+++ b/src/urg_c_wrapper.cpp
@@ -397,12 +397,12 @@ bool URGCWrapper::getAR00Status(URGStatus & status)
   uint16_t unused0;
 
   s = response.substr(17, 1);
-  unused0 = std::stoul(s, nullptr, 16);
-  RCLCPP_DEBUG(logger_, "OSSD 1: 0x%s = %d", s.c_str(), unused0);
+  status.ossd_1 = std::stoul(s, nullptr, 16);
+  RCLCPP_DEBUG(logger_, "OSSD 1: 0x%s = %d", s.c_str(), status.ossd_1);
 
   s = response.substr(18, 1);
-  unused0 = std::stoul(s, nullptr, 16);
-  RCLCPP_DEBUG(logger_, "OSSD 2: 0x%s = %d", s.c_str(), unused0);
+  status.ossd_2 = std::stoul(s, nullptr, 16);
+  RCLCPP_DEBUG(logger_, "OSSD 2: 0x%s = %d", s.c_str(), status.ossd_2);
 
   s = response.substr(19, 1);
   unused0 = std::stoul(s, nullptr, 16);

--- a/src/urg_node.cpp
+++ b/src/urg_node.cpp
@@ -167,6 +167,8 @@ bool UrgNode::updateStatus()
         msg.error_code = status.error_code;
         msg.lockout_status = status.lockout_status;
         msg.optical_window_contaminated = status.optical_window_contaminated;
+        msg.ossd_1 = status.ossd_1;
+        msg.ossd_2 = status.ossd_2;
 
         lockout_status_ = status.lockout_status;
         error_code_ = status.error_code;


### PR DESCRIPTION
Reads the ossd_1 and ossd_2 value from the response of the sent AR00 command and publishes it to ROS.
